### PR TITLE
Add missing .env file contain ELK_VERSION

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ELK_VERSION=6.5.4


### PR DESCRIPTION
This was causing:

	$ env ELK_VERSION=651 docker-compose up
	WARNING: The GETH_VERSION variable is not set. Defaulting to a blank
	string.
	WARNING: The FILEBEAT_VERSION variable is not set. Defaulting to a blank
	string.
	Building elasticsearch
	Step 1/2 : ARG ELK_VERSION
	Step 2/2 : FROM
	docker.elastic.co/elasticsearch/elasticsearch-oss:${ELK_VERSION}
	ERROR: Service 'elasticsearch' failed to build: manifest for
	docker.elastic.co/elasticsearch/elasticsearch-oss:651 not found

> https://github.com/deviantony/docker-elk/issues/311